### PR TITLE
add option for tooltips

### DIFF
--- a/src/Forms/Nouislider.php
+++ b/src/Forms/Nouislider.php
@@ -132,7 +132,7 @@ class Nouislider extends Field implements Contracts\HasAffixActions
         return $this;
     }
 
-    public function tooltips($value): static
+    public function tooltips($value = true): static
     {
         $this->tooltips = $value;
 

--- a/src/Forms/Nouislider.php
+++ b/src/Forms/Nouislider.php
@@ -58,6 +58,8 @@ class Nouislider extends Field implements Contracts\HasAffixActions
      */
     protected $minValue = null;
 
+    protected bool | Closure | null $tooltips = false;
+
     /**
      * @var view-string
      */
@@ -130,6 +132,13 @@ class Nouislider extends Field implements Contracts\HasAffixActions
         return $this;
     }
 
+    public function tooltips($value): static
+    {
+        $this->tooltips = $value;
+
+        return $this;
+    }
+
     public function orientation($value)
     {
         $this->orientation = $value;
@@ -161,6 +170,11 @@ class Nouislider extends Field implements Contracts\HasAffixActions
     public function getMinValue()
     {
         return $this->evaluate($this->minValue);
+    }
+
+    public function getTooltips()
+    {
+        return $this->evaluate($this->tooltips);
     }
 
     public function getSnap()
@@ -260,6 +274,7 @@ class Nouislider extends Field implements Contracts\HasAffixActions
             'animate' => $this->getAnimate(),
             'animationDuration' => $this->getAnimationDuration(),
             'cssPrefix' => $this->getCssPrefix(),
+            'tooltips' => $this->getTooltips(),
         ];
     }
 }


### PR DESCRIPTION
I added the option to enable tooltips on the slider
before:
<img width="413" alt="Screenshot 2023-10-12 at 6 29 39 PM" src="https://github.com/sawirricardo/filament-nouislider/assets/1952412/3fd33184-9cea-4521-8eb8-9f2f6f4f91f2">

after:
<img width="336" alt="Screenshot 2023-10-12 at 6 29 49 PM" src="https://github.com/sawirricardo/filament-nouislider/assets/1952412/7aa4218e-a350-44b4-a9d1-8f263aaf3aad">

usage:

```
Nouislider::make('slider')
                ->tooltips()
```